### PR TITLE
builder: implement writer that does not require preinitialisation

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -151,7 +151,7 @@ impl<'a> RtpPacketBuilder<'a> {
     /// Write this packet into `buf` without any validity checks.  Returns the number of bytes
     /// written.
     pub fn write_into_unchecked(self, buf: &mut [u8]) -> usize {
-        let mut byte = 0x80; // rtp version 24
+        let mut byte = 0x80; // rtp version 2
         if self.padding.is_some() {
             byte |= 0x20;
         }
@@ -218,9 +218,7 @@ impl<'a> RtpPacketBuilder<'a> {
         write_i
     }
 
-    /// Write this packet into `buf`.  On success returns the number of bytes written or an
-    /// `RtpWriteError` on failure.
-    pub fn write_into(self, buf: &mut [u8]) -> Result<usize, RtpWriteError> {
+    fn write_preconditions(&self) -> Result<(), RtpWriteError> {
         if self.payload_type > 0x7f {
             return Err(RtpWriteError::InvalidPayloadType(self.payload_type));
         }
@@ -234,12 +232,93 @@ impl<'a> RtpPacketBuilder<'a> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Write this packet into `buf`.  On success returns the number of bytes written or an
+    /// `RtpWriteError` on failure.
+    pub fn write_into(self, buf: &mut [u8]) -> Result<usize, RtpWriteError> {
+        self.write_preconditions()?;
+
         let size = self.calculate_size()?;
         if size > buf.len() {
             return Err(RtpWriteError::OutputTooSmall(size));
         }
 
         Ok(self.write_into_unchecked(buf))
+    }
+
+    /// Write this packet into `buf` without any validity checks.  Returns the number of bytes
+    /// written.
+    pub fn write_unchecked(self, buf: &mut Vec<u8>) -> usize {
+        let start_len = buf.len();
+
+        let mut byte = 0x80; // rtp version 2
+        if self.padding.is_some() {
+            byte |= 0x20;
+        }
+        if self.extension.is_some() {
+            byte |= 0x10;
+        }
+        byte |= (self.csrcs.len() as u8) & 0x0f;
+        buf.push(byte);
+
+        let mut byte = self.payload_type & 0x7f;
+        if self.marker {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+
+        buf.push((self.sequence_number >> 8) as u8);
+        buf.push((self.sequence_number & 0xff) as u8);
+
+        buf.push((self.timestamp >> 24) as u8);
+        buf.push(((self.timestamp >> 16) & 0xff) as u8);
+        buf.push(((self.timestamp >> 8) & 0xff) as u8);
+        buf.push((self.timestamp & 0xff) as u8);
+
+        buf.push((self.ssrc >> 24) as u8);
+        buf.push(((self.ssrc >> 16) & 0xff) as u8);
+        buf.push(((self.ssrc >> 8) & 0xff) as u8);
+        buf.push((self.ssrc & 0xff) as u8);
+
+        for csrc in self.csrcs {
+            buf.push((csrc >> 24) as u8);
+            buf.push(((csrc >> 16) & 0xff) as u8);
+            buf.push(((csrc >> 8) & 0xff) as u8);
+            buf.push((csrc & 0xff) as u8);
+        }
+
+        if let Some((ext_id, ext_data)) = self.extension {
+            buf.push((ext_id >> 8) as u8);
+            buf.push((ext_id & 0xff) as u8);
+            buf.push((((ext_data.len() / 4) >> 8) & 0xff) as u8);
+            buf.push(((ext_data.len() / 4) & 0xff) as u8);
+            if !ext_data.is_empty() {
+                buf.extend(ext_data);
+            }
+        }
+
+        for &payload in &self.payloads {
+            buf.extend(payload);
+        }
+
+        if let Some(padding) = self.padding {
+            buf.extend(std::iter::repeat(0).take(padding as usize - 1));
+            buf.push(padding);
+        }
+
+        buf.len() - start_len
+    }
+
+    /// Write the packet into `buf` appending to any data that already exists.
+    /// Returns the number of bytes written.
+    pub fn write(self, buf: &mut Vec<u8>) -> Result<usize, RtpWriteError> {
+        self.write_preconditions()?;
+        let len = self.calculate_size()?;
+
+        buf.reserve(len);
+        Ok(self.write_unchecked(buf))
     }
 }
 
@@ -250,73 +329,84 @@ mod tests {
     #[test]
     fn write_rtp_default() {
         let mut data = [0; 128];
-        let size = RtpPacketBuilder::new()
-            .payload_type(96)
-            .write_into(&mut data)
-            .unwrap();
+        let builder = RtpPacketBuilder::new().payload_type(96);
+        let size = builder.clone().write_into(&mut data).unwrap();
         let data = &data[..size];
-        println!("{data:?}");
-        let rtp = RtpPacket::parse(data).unwrap();
-        assert_eq!(rtp.version(), 2);
-        assert_eq!(rtp.padding(), None);
-        assert_eq!(rtp.n_csrcs(), 0);
-        assert!(!rtp.marker());
-        assert_eq!(rtp.payload_type(), 96);
-        assert_eq!(rtp.sequence_number(), 0x0);
-        assert_eq!(rtp.timestamp(), 0x0);
-        assert_eq!(rtp.ssrc(), 0x0);
-        assert_eq!(rtp.csrc().count(), 0);
-        assert_eq!(rtp.extension(), None);
-        assert_eq!(rtp.payload(), &[]);
+        let mut buf = vec![];
+        let size_owned = builder.write(&mut buf).unwrap();
+        assert_eq!(size, size_owned);
+        for data in [data, buf.as_ref()] {
+            println!("{data:?}");
+            let rtp = RtpPacket::parse(data).unwrap();
+            assert_eq!(rtp.version(), 2);
+            assert_eq!(rtp.padding(), None);
+            assert_eq!(rtp.n_csrcs(), 0);
+            assert!(!rtp.marker());
+            assert_eq!(rtp.payload_type(), 96);
+            assert_eq!(rtp.sequence_number(), 0x0);
+            assert_eq!(rtp.timestamp(), 0x0);
+            assert_eq!(rtp.ssrc(), 0x0);
+            assert_eq!(rtp.csrc().count(), 0);
+            assert_eq!(rtp.extension(), None);
+            assert_eq!(rtp.payload(), &[]);
+        }
     }
 
     #[test]
     fn write_rtp_header() {
         let mut data = [0; 128];
-        let size = RtpPacketBuilder::new()
+        let builder = RtpPacketBuilder::new()
             .payload_type(96)
             .marker(true)
             .sequence_number(0x0102)
             .timestamp(0x03040506)
             .ssrc(0x0708090a)
-            .add_csrc(0x0b0c0d0e)
-            .write_into(&mut data)
-            .unwrap();
+            .add_csrc(0x0b0c0d0e);
+        let size = builder.clone().write_into(&mut data).unwrap();
         let data = &data[..size];
-        println!("{data:?}");
-        let rtp = RtpPacket::parse(data).unwrap();
-        assert_eq!(rtp.version(), 2);
-        assert_eq!(rtp.padding(), None);
-        assert_eq!(rtp.n_csrcs(), 1);
-        assert!(rtp.marker());
-        assert_eq!(rtp.payload_type(), 96);
-        assert_eq!(rtp.sequence_number(), 0x0102);
-        assert_eq!(rtp.timestamp(), 0x03040506);
-        assert_eq!(rtp.ssrc(), 0x0708090a);
-        let mut csrc = rtp.csrc();
-        assert_eq!(csrc.next(), Some(0x0b0c0d0e));
-        assert_eq!(csrc.next(), None);
-        assert_eq!(rtp.extension(), None);
-        assert_eq!(rtp.payload(), &[]);
+        let mut buf = vec![];
+        let size_owned = builder.write(&mut buf).unwrap();
+        assert_eq!(size, size_owned);
+        for data in [data, buf.as_ref()] {
+            println!("{data:?}");
+            let rtp = RtpPacket::parse(data).unwrap();
+            assert_eq!(rtp.version(), 2);
+            assert_eq!(rtp.padding(), None);
+            assert_eq!(rtp.n_csrcs(), 1);
+            assert!(rtp.marker());
+            assert_eq!(rtp.payload_type(), 96);
+            assert_eq!(rtp.sequence_number(), 0x0102);
+            assert_eq!(rtp.timestamp(), 0x03040506);
+            assert_eq!(rtp.ssrc(), 0x0708090a);
+            let mut csrc = rtp.csrc();
+            assert_eq!(csrc.next(), Some(0x0b0c0d0e));
+            assert_eq!(csrc.next(), None);
+            assert_eq!(rtp.extension(), None);
+            assert_eq!(rtp.payload(), &[]);
+        }
     }
 
     #[test]
     fn write_rtp_header_multiple_csrcs() {
         let mut data = [0; 128];
-        let size = RtpPacketBuilder::new()
+        let builder = RtpPacketBuilder::new()
             .payload_type(96)
             .add_csrc(0x01020304)
-            .add_csrc(0x05060708)
-            .write_into(&mut data)
-            .unwrap();
+            .add_csrc(0x05060708);
+        let size = builder.clone().write_into(&mut data).unwrap();
         let data = &data[..size];
-        println!("{data:?}");
-        let rtp = RtpPacket::parse(data).unwrap();
-        assert_eq!(rtp.n_csrcs(), 2);
-        let mut csrc = rtp.csrc();
-        assert_eq!(csrc.next(), Some(0x01020304));
-        assert_eq!(csrc.next(), Some(0x05060708));
-        assert_eq!(csrc.next(), None);
+        let mut buf = vec![];
+        let size_owned = builder.write(&mut buf).unwrap();
+        assert_eq!(size, size_owned);
+        for data in [data, buf.as_ref()] {
+            println!("{data:?}");
+            let rtp = RtpPacket::parse(data).unwrap();
+            assert_eq!(rtp.n_csrcs(), 2);
+            let mut csrc = rtp.csrc();
+            assert_eq!(csrc.next(), Some(0x01020304));
+            assert_eq!(csrc.next(), Some(0x05060708));
+            assert_eq!(csrc.next(), None);
+        }
     }
 
     #[test]
@@ -324,52 +414,60 @@ mod tests {
         let mut data = [0; 128];
         let payload_data = [1, 2, 3, 4, 5, 6, 7, 8];
         let more_payload_data = [9, 10, 11];
-        let size = RtpPacketBuilder::new()
+        let builder = RtpPacketBuilder::new()
             .payload_type(96)
             .payload(&payload_data)
             .payload(&more_payload_data)
-            .payload(&more_payload_data[0..1])
-            .write_into(&mut data)
-            .unwrap();
+            .payload(&more_payload_data[0..1]);
+        let size = builder.clone().write_into(&mut data).unwrap();
         assert_eq!(size, 24);
         let data = &data[..size];
-        println!("{data:?}");
-        let rtp = RtpPacket::parse(data).unwrap();
-        assert_eq!(rtp.version(), 2);
-        assert_eq!(rtp.payload_type(), 96);
-        assert_eq!(rtp.payload(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 9]);
+        let mut buf = vec![];
+        let size_owned = builder.write(&mut buf).unwrap();
+        assert_eq!(size, size_owned);
+        for data in [data, buf.as_ref()] {
+            println!("{data:?}");
+            let rtp = RtpPacket::parse(data).unwrap();
+            assert_eq!(rtp.version(), 2);
+            assert_eq!(rtp.payload_type(), 96);
+            assert_eq!(rtp.payload(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 9]);
+        }
     }
 
     #[test]
     fn write_rtp_extension() {
         let mut data = [0; 128];
         let extension_data = [1, 2, 3, 4, 5, 6, 7, 8];
-        let size = RtpPacketBuilder::new()
+        let builder = RtpPacketBuilder::new()
             .payload_type(96)
             .marker(true)
             .sequence_number(0x0102)
             .timestamp(0x03040506)
             .ssrc(0x0708090a)
             .add_csrc(0x0b0c0d0e)
-            .extension(0x9876, &extension_data)
-            .write_into(&mut data)
-            .unwrap();
+            .extension(0x9876, &extension_data);
+        let size = builder.clone().write_into(&mut data).unwrap();
         let data = &data[..size];
-        println!("{data:?}");
-        let rtp = RtpPacket::parse(data).unwrap();
-        assert_eq!(rtp.version(), 2);
-        assert_eq!(rtp.padding(), None);
-        assert_eq!(rtp.n_csrcs(), 1);
-        assert!(rtp.marker());
-        assert_eq!(rtp.payload_type(), 96);
-        assert_eq!(rtp.sequence_number(), 0x0102);
-        assert_eq!(rtp.timestamp(), 0x03040506);
-        assert_eq!(rtp.ssrc(), 0x0708090a);
-        let mut csrc = rtp.csrc();
-        assert_eq!(csrc.next(), Some(0x0b0c0d0e));
-        assert_eq!(csrc.next(), None);
-        assert_eq!(rtp.extension(), Some((0x9876, extension_data.as_ref())));
-        assert_eq!(rtp.payload(), &[]);
+        let mut buf = vec![];
+        let size_owned = builder.write(&mut buf).unwrap();
+        assert_eq!(size, size_owned);
+        for data in [data, buf.as_ref()] {
+            println!("{data:?}");
+            let rtp = RtpPacket::parse(data).unwrap();
+            assert_eq!(rtp.version(), 2);
+            assert_eq!(rtp.padding(), None);
+            assert_eq!(rtp.n_csrcs(), 1);
+            assert!(rtp.marker());
+            assert_eq!(rtp.payload_type(), 96);
+            assert_eq!(rtp.sequence_number(), 0x0102);
+            assert_eq!(rtp.timestamp(), 0x03040506);
+            assert_eq!(rtp.ssrc(), 0x0708090a);
+            let mut csrc = rtp.csrc();
+            assert_eq!(csrc.next(), Some(0x0b0c0d0e));
+            assert_eq!(csrc.next(), None);
+            assert_eq!(rtp.extension(), Some((0x9876, extension_data.as_ref())));
+            assert_eq!(rtp.payload(), &[]);
+        }
     }
 
     #[test]
@@ -377,7 +475,7 @@ mod tests {
         let mut data = [0; 128];
         let extension_data = [1, 2, 3, 4, 5, 6, 7, 8];
         let payload_data = [1, 2, 3, 4, 5, 6, 7, 8];
-        let size = RtpPacketBuilder::new()
+        let builder = RtpPacketBuilder::new()
             .payload_type(96)
             .marker(true)
             .sequence_number(0x0102)
@@ -386,47 +484,56 @@ mod tests {
             .add_csrc(0x0b0c0d0e)
             .extension(0x9876, &extension_data)
             .payload(&payload_data)
-            .padding(7)
-            .write_into(&mut data)
-            .unwrap();
+            .padding(7);
+        let size = builder.clone().write_into(&mut data).unwrap();
         let data = &data[..size];
-        println!("{data:?}");
-        let rtp = RtpPacket::parse(data).unwrap();
-        assert_eq!(rtp.version(), 2);
-        assert_eq!(rtp.padding(), Some(7));
-        assert_eq!(rtp.n_csrcs(), 1);
-        assert!(rtp.marker());
-        assert_eq!(rtp.payload_type(), 96);
-        assert_eq!(rtp.sequence_number(), 0x0102);
-        assert_eq!(rtp.timestamp(), 0x03040506);
-        assert_eq!(rtp.ssrc(), 0x0708090a);
-        let mut csrc = rtp.csrc();
-        assert_eq!(csrc.next(), Some(0x0b0c0d0e));
-        assert_eq!(csrc.next(), None);
-        assert_eq!(rtp.extension(), Some((0x9876, extension_data.as_ref())));
-        assert_eq!(rtp.payload(), payload_data.as_ref());
+        let mut buf = vec![];
+        let size_owned = builder.write(&mut buf).unwrap();
+        assert_eq!(size, size_owned);
+        for data in [data, buf.as_ref()] {
+            println!("{data:?}");
+            let rtp = RtpPacket::parse(data).unwrap();
+            assert_eq!(rtp.version(), 2);
+            assert_eq!(rtp.padding(), Some(7));
+            assert_eq!(rtp.n_csrcs(), 1);
+            assert!(rtp.marker());
+            assert_eq!(rtp.payload_type(), 96);
+            assert_eq!(rtp.sequence_number(), 0x0102);
+            assert_eq!(rtp.timestamp(), 0x03040506);
+            assert_eq!(rtp.ssrc(), 0x0708090a);
+            let mut csrc = rtp.csrc();
+            assert_eq!(csrc.next(), Some(0x0b0c0d0e));
+            assert_eq!(csrc.next(), None);
+            assert_eq!(rtp.extension(), Some((0x9876, extension_data.as_ref())));
+            assert_eq!(rtp.payload(), payload_data.as_ref());
+        }
     }
 
     #[test]
     fn write_rtp_invalid_padding() {
         let mut data = [0; 128];
+        let builder = RtpPacketBuilder::new().payload_type(96).padding(0);
         assert_eq!(
-            RtpPacketBuilder::new()
-                .payload_type(96)
-                .padding(0)
-                .write_into(&mut data),
+            builder.clone().write_into(&mut data),
             Err(RtpWriteError::InvalidPadding)
         );
+        let mut data = vec![];
+        assert_eq!(builder.write(&mut data), Err(RtpWriteError::InvalidPadding));
     }
 
     #[test]
     fn write_rtp_unpadded_extension() {
         let mut data = [0; 128];
+        let builder = RtpPacketBuilder::new()
+            .payload_type(96)
+            .extension(0x9876, &[1]);
         assert_eq!(
-            RtpPacketBuilder::new()
-                .payload_type(96)
-                .extension(0x9876, &[1])
-                .write_into(&mut data),
+            builder.clone().write_into(&mut data),
+            Err(RtpWriteError::ExtensionDataNotPadded)
+        );
+        let mut data = vec![];
+        assert_eq!(
+            builder.clone().write(&mut data),
             Err(RtpWriteError::ExtensionDataNotPadded)
         );
     }
@@ -434,10 +541,14 @@ mod tests {
     #[test]
     fn write_rtp_invalid_payload_type() {
         let mut data = [0; 128];
+        let builder = RtpPacketBuilder::new().payload_type(0xFF);
         assert_eq!(
-            RtpPacketBuilder::new()
-                .payload_type(0xFF)
-                .write_into(&mut data),
+            builder.clone().write_into(&mut data),
+            Err(RtpWriteError::InvalidPayloadType(0xFF))
+        );
+        let mut data = vec![];
+        assert_eq!(
+            builder.write(&mut data),
             Err(RtpWriteError::InvalidPayloadType(0xFF))
         );
     }
@@ -445,26 +556,31 @@ mod tests {
     #[test]
     fn write_rtp_too_many_contributions() {
         let mut data = [0; 128];
+        let builder = RtpPacketBuilder::new()
+            .payload_type(96)
+            .add_csrc(1)
+            .add_csrc(2)
+            .add_csrc(3)
+            .add_csrc(4)
+            .add_csrc(5)
+            .add_csrc(6)
+            .add_csrc(7)
+            .add_csrc(8)
+            .add_csrc(9)
+            .add_csrc(10)
+            .add_csrc(11)
+            .add_csrc(12)
+            .add_csrc(13)
+            .add_csrc(14)
+            .add_csrc(15)
+            .add_csrc(16);
         assert_eq!(
-            RtpPacketBuilder::new()
-                .payload_type(96)
-                .add_csrc(1)
-                .add_csrc(2)
-                .add_csrc(3)
-                .add_csrc(4)
-                .add_csrc(5)
-                .add_csrc(6)
-                .add_csrc(7)
-                .add_csrc(8)
-                .add_csrc(9)
-                .add_csrc(10)
-                .add_csrc(11)
-                .add_csrc(12)
-                .add_csrc(13)
-                .add_csrc(14)
-                .add_csrc(15)
-                .add_csrc(16)
-                .write_into(&mut data),
+            builder.clone().write_into(&mut data),
+            Err(RtpWriteError::TooManyContributionSources(16))
+        );
+        let mut data = vec![];
+        assert_eq!(
+            builder.write(&mut data),
             Err(RtpWriteError::TooManyContributionSources(16))
         );
     }
@@ -473,13 +589,15 @@ mod tests {
     fn write_rtp_extension_too_large() {
         let mut data = [0; u16::MAX as usize + 128];
         let extension_data = [0; u16::MAX as usize + 1];
+        let builder = RtpPacketBuilder::new()
+            .payload_type(96)
+            .extension(0x9876, &extension_data);
         assert_eq!(
-            RtpPacketBuilder::new()
-                .payload_type(96)
-                .extension(0x9876, &extension_data)
-                .write_into(&mut data),
+            builder.clone().write_into(&mut data),
             Err(RtpWriteError::PacketTooLarge)
         );
+        let mut data = vec![];
+        assert_eq!(builder.write(&mut data), Err(RtpWriteError::PacketTooLarge));
     }
 
     #[test]


### PR DESCRIPTION
Writes to a Vec<u8> for now but may be extended later with a trait for writing to other data structures.