### PR TITLE
builder: implement support for custom payload/extension data types

### DIFF
--- a/fuzz/fuzz_targets/rtp_from_bytes.rs
+++ b/fuzz/fuzz_targets/rtp_from_bytes.rs
@@ -3,8 +3,7 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(packet) = rtp_types::RtpPacket::parse(data) {
-        let mut built = vec![];
-        packet.as_builder().write(&mut built).unwrap();
+        let built = packet.as_builder().write_vec().unwrap();
         if let Some(padding) = packet.padding() {
             // ignore any padding as its contents in the original data are undefined
             assert_eq!(&built[..built.len() - padding as usize], &data[..data.len() - padding as usize]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,13 @@ mod builder;
 mod edit;
 mod packet;
 
-pub use builder::{RtpPacketBuilder, RtpWriteError};
+pub use builder::{
+    RtpPacketBuilder, RtpPacketWriterMutSlice, RtpPacketWriterMutVec, RtpPacketWriterVec,
+    RtpWriteError,
+};
 pub use edit::RtpPacketMut;
 pub use packet::{RtpPacket, RtpParseError};
+
+pub mod prelude {
+    pub use crate::builder::{PayloadLength, RtpPacketWriter};
+}

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -257,7 +257,7 @@ impl<'a> RtpPacket<'a> {
 
     /// Creates a builder that will be able to reconstruct this packet byte for byte (excluding
     /// any padding bytes).  Any aspect of the returned builder can be modified.
-    pub fn as_builder(&'a self) -> crate::RtpPacketBuilder<'a> {
+    pub fn as_builder(&'a self) -> crate::RtpPacketBuilder<&'a [u8], &'a [u8]> {
         let mut builder = crate::RtpPacketBuilder::new()
             .marker(self.marker())
             .payload_type(self.payload_type())
@@ -299,8 +299,7 @@ mod tests {
         assert_eq!(rtp.csrc().count(), 0);
         assert_eq!(rtp.extension(), None);
         assert_eq!(rtp.payload(), &[]);
-        let mut built = vec![];
-        rtp.as_builder().write(&mut built).unwrap();
+        let built = rtp.as_builder().write_vec().unwrap();
         assert_eq!(built, data.as_ref());
     }
 
@@ -338,8 +337,7 @@ mod tests {
         assert_eq!(csrc.next(), None);
         assert_eq!(rtp.extension(), None);
         assert_eq!(rtp.payload(), &[]);
-        let mut built = vec![];
-        rtp.as_builder().write(&mut built).unwrap();
+        let built = rtp.as_builder().write_vec().unwrap();
         assert_eq!(built, data.as_ref());
     }
 
@@ -379,8 +377,7 @@ mod tests {
             Some((0x0b0c, [0x0d, 0x0e, 0x0f, 0x10].as_ref()))
         );
         assert_eq!(rtp.payload(), &[]);
-        let mut built = vec![];
-        rtp.as_builder().write(&mut built).unwrap();
+        let built = rtp.as_builder().write_vec().unwrap();
         assert_eq!(built, data.as_ref());
     }
 
@@ -432,8 +429,7 @@ mod tests {
         assert_eq!(rtp.csrc().count(), 0);
         assert_eq!(rtp.extension(), None);
         assert_eq!(rtp.payload(), &[0x0b, 0x0c, 0x0d, 0x0e]);
-        let mut built = vec![];
-        rtp.as_builder().write(&mut built).unwrap();
+        let built = rtp.as_builder().write_vec().unwrap();
         assert_eq!(built, data.as_ref());
     }
 
@@ -455,8 +451,7 @@ mod tests {
         assert_eq!(rtp.csrc().count(), 0);
         assert_eq!(rtp.extension(), None);
         assert_eq!(rtp.payload(), &[0x0b, 0x0c]);
-        let mut built = vec![];
-        rtp.as_builder().write(&mut built).unwrap();
+        let built = rtp.as_builder().write_vec().unwrap();
         assert_eq!(built, data.as_ref());
     }
 


### PR DESCRIPTION
The actual writing for these custom types is implementable by implementing a RtpPacketWriter trait.